### PR TITLE
79 fix radio driver encoding

### DIFF
--- a/EosGround/radioDriver.py
+++ b/EosGround/radioDriver.py
@@ -15,6 +15,7 @@ from EosLib.packet.packet import Packet
 import EosLib.packet.definitions
 import EosLib.packet.packet
 import EosLib.packet.transmit_header
+from EosLib.format.decode_factory import decode_factory
 
 from config.config import get_config
 from EosGround.database.pipeline.pipelines.raw_data_pipeline import PacketPipeline
@@ -90,10 +91,12 @@ def send_command():
 
             data_header.destination = packet_destination  # added externally
 
+            packet_body = decode_factory.decode(packet_type, packet_body)
+
             transmit_header = EosLib.packet.transmit_header.TransmitHeader(sequence_number)
             transmit_header.send_time = datetime.datetime.now()
 
-            packet = Packet(data_header=data_header, body=packet_body.encode())  # transmit packet
+            packet = Packet(data_header=data_header, body=packet_body)  # transmit packet
             packet.transmit_header = transmit_header
 
             device.send_data_async(remote, packet.encode(), transmit_options=TransmitOptions.DISABLE_ACK.value)

--- a/postgresDB/dbApp/admin.py
+++ b/postgresDB/dbApp/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
 # Register your models here.
-#from dbApp.models import RawData
+from .models import TerminalOutput
 # Register your models here.
-#admin.site.register(RawData)
+admin.site.register(TerminalOutput)

--- a/postgresDB/dbApp/forms.py
+++ b/postgresDB/dbApp/forms.py
@@ -1,0 +1,4 @@
+from django import forms
+
+class TerminalInputForm(forms.Form):
+    command = forms.CharField(max_length=255)

--- a/postgresDB/dbApp/models.py
+++ b/postgresDB/dbApp/models.py
@@ -87,8 +87,18 @@ class TransmitTable(models.Model):
     priority = models.IntegerField()
     destination = models.IntegerField()
     generate_time = models.DateTimeField()
-    body = models.CharField(max_length=255)
+    body = models.BinaryField()
 
     class Meta:
         managed = False
         db_table = 'transmit_table'
+
+class TerminalOutput(models.Model):
+    received_packet = models.ForeignKey(ReceivedPackets, on_delete=models.DO_NOTHING)
+    transmit_table = models.ForeignKey(TransmitTable, on_delete=models.DO_NOTHING)
+    terminal_output = models.CharField(max_length=255)
+
+    class Meta:
+        managed = False
+        db_table = 'terminal_output'
+

--- a/postgresDB/dbApp/serializers.py
+++ b/postgresDB/dbApp/serializers.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
-from .models import Position, Telemetry, TestData
+from .models import Position, Telemetry, TestData, TerminalOutput
 
 # serializers translate the models into a different formats like JSON
-
+# pk stands for primary key and Django automatically creates this for you
 
 class PositionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -21,3 +21,8 @@ class TestDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestData
         fields = ['pk', 'rand_int']
+
+class TerminalOutputSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TerminalOutput
+        fields = ['received_packet_id', 'transmit_table_id', 'terminal_output']

--- a/postgresDB/dbApp/urls.py
+++ b/postgresDB/dbApp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import include, path
-from .views import PositionList, TelemetryList, TestDataList
+from .views import PositionList, TelemetryList, TestDataList, TerminalOutputList, transmitTableInsert
 
 # this is where we put the endpoint urls
 # the postgresDB/urls.py file also has to be updated accordingly
@@ -8,4 +8,6 @@ urlpatterns = [
     path('pos/<int:pk>/', PositionList.as_view(), name='retrieve-position'),
     path('tel/<int:pk>/', TelemetryList.as_view(), name='retrieve-telemetry'),
     path('test/<int:pk>/', TestDataList.as_view(), name='retrieve-testdata'),
+    path('terminal/', TerminalOutputList.as_view(), name='terminal-output'),
+    path('insertTransmitTable/', transmitTableInsert, name='transmit-table-insert')
 ]

--- a/postgresDB/dbApp/views.py
+++ b/postgresDB/dbApp/views.py
@@ -1,7 +1,24 @@
 # Create your views here.
-from .models import Position, Telemetry, TestData
-from .serializers import PositionSerializer, TelemetrySerializer, TestDataSerializer
+import json
+
+from django.http import HttpResponse, JsonResponse
+from rest_framework.decorators import api_view
+from .forms import TerminalInputForm
+
+from .models import Position, Telemetry, TestData, TerminalOutput, TransmitTable
+from .serializers import PositionSerializer, TelemetrySerializer, TestDataSerializer, TerminalOutputSerializer
 from rest_framework import generics
+from rest_framework import status
+from rest_framework.response import Response
+from EosLib.device import Device
+#from EosLib.format import Type
+from EosLib.format.definitions import Type
+from EosLib.format.formats.cutdown import CutDown
+from EosLib.format.formats.ping_format import Ping
+from EosLib.packet import Packet
+from EosLib.packet.data_header import DataHeader
+from EosLib.packet.definitions import Priority
+import datetime
 
 # API endpoint that allows data to be viewed.
 
@@ -19,3 +36,47 @@ class TelemetryList(generics.RetrieveAPIView):
 class TestDataList(generics.RetrieveAPIView):
     queryset = TestData.objects.all()
     serializer_class = TestDataSerializer
+
+class TerminalOutputList(generics.ListAPIView):
+    queryset = TerminalOutput.objects.all()
+    serializer_class = TerminalOutputSerializer
+
+
+@api_view(['POST'])
+def transmitTableInsert(request, ack: int=0):
+    if request.method == 'POST':
+        #input = request.POST.get('input')
+        form = TerminalInputForm(request.POST)
+        if form.is_valid():
+            input = form.cleaned_data['command']
+            if input.startswith('cut'):
+                cutdown = CutDown(ack)
+                cutdown_packet = Packet(cutdown, DataHeader(Device.GROUND_STATION_1, Type.CUTDOWN, Priority.TELEMETRY))
+                cutdown_packet_binary = cutdown_packet.encode()
+                transmitTable = TransmitTable()
+                transmitTable.body = cutdown_packet_binary
+                transmitTable.save()
+                return Response({'message': 'Ping command received and processed'}, status=status.HTTP_200_OK)
+            elif input.startswith('ping'):
+                ping = Ping(True, ack)
+                ping_packet = Packet(ping, DataHeader(Device.GROUND_STATION_1, Type.PING, Priority.TELEMETRY))
+                ping_packet_binary = ping_packet.encode()
+                transmitTable = TransmitTable()
+                transmitTable.body = ping_packet_binary
+                transmitTable.save()
+                return Response({'message': 'Ping command received and processed'}, status=status.HTTP_200_OK)
+
+            else:
+                 return Response({'error': 'Invalid command'}, status=status.HTTP_400_BAD_REQUEST)
+
+    return Response({'Hello': 'Invalid input or method'}, status=status.HTTP_400_BAD_REQUEST)
+
+
+
+
+
+
+
+
+
+

--- a/postgresDB/postgresDB/settings.py
+++ b/postgresDB/postgresDB/settings.py
@@ -86,7 +86,7 @@ DATABASES = {
         },
         'NAME': 'eos_db',
         'USER': 'postgres',
-        'PASSWORD': '',
+        'PASSWORD': 'password',
         'HOST': '127.0.0.1',
         'PORT': '5432',
     }


### PR DESCRIPTION
Made a small change to pass the decoded format to the Packet class in the radio driver. The packet body the driver grabs is initially encoded, so we need to decode it before we pass it to Packet. NEEDS TO BE TESTED BEFORE APPROVING/MERGING.